### PR TITLE
Avoid the CS0433 error

### DIFF
--- a/src/NAnt.Console/NAnt.Console.build
+++ b/src/NAnt.Console/NAnt.Console.build
@@ -34,7 +34,6 @@
             <references>
                 <include name="${build.dir}/bin/log4net.dll" />
                 <include name="System.Configuration.dll" />
-                <include name="System.Xml.dll" />
             </references>
             <resources>
                 <include name="*.resx"/>


### PR DESCRIPTION
```
build:

            [build csc] Compiling 3 files to '/Users/nandub/development/code/ikvm-conv/nant/build/mono-4.5.unix/nant-debug/bin/NAnt.exe'.
            [build csc] Compiling 35 files to '/Users/nandub/development/code/ikvm-conv/nant/build/mono-4.5.unix/nant-debug/bin/NAnt.DotNetTasks.dll'.
            [build csc] Compiling 70 files to '/Users/nandub/development/code/ikvm-conv/nant/build/mono-4.5.unix/nant-debug/bin/NAnt.Core.Tests.dll'.
                           [resgen] Read in 77 resources from '/Users/nandub/development/code/ikvm-conv/nant/src/NAnt.DotNet/Resources/Strings.resx'
                           [resgen] Writing resource file...  Done.
            [build csc] /Users/nandub/development/code/ikvm-conv/nant/src/NAnt.Console/ConsoleStub.cs(480,17): error CS0433: The imported type `System.Xml.XmlNode' is defined multiple times
            [build csc] /usr/local/lib/mono/4.5/System.Xml.dll (Location of the symbol related to previous error)
            [build csc] /usr/local/Cellar/mono/5.20.1.19/lib/mono/4.5-api/System.Xml.dll (Location of the symbol related to previous error)
            [build csc] /Users/nandub/development/code/ikvm-conv/nant/src/NAnt.Console/ConsoleStub.cs(488,17): error CS0433: The imported type `System.Xml.XmlElement' is defined multiple times
            [build csc] /usr/local/lib/mono/4.5/System.Xml.dll (Location of the symbol related to previous error)
            [build csc] /usr/local/Cellar/mono/5.20.1.19            [build csc] /usr/local/Cellar/mono/5.20.1.19            [build csc] /usr/local/Cellar/mono/5.20.1.19            [build csc] /usikvm-conv/            [build csc] /usr/local/Cellar/mono/5.20.1.1933: The imported type `System.Xml.XmlNodeList' is defined multiple times
            [build csc] /usr/local/lib/mono/4.5/System.Xml.dll (Location of the symbol related to previous error)
            [build csc] /usr/local/Cellar/mono/5.20.1.19/lib/mono/4.5-api/System.Xml.dll (Location of the symbol related to previous error)
            [build csc] Compilation failed: 3 error(s), 0 warnings

            BUILD FAILED - 0 non-fatal error(s), 9 warning(s)

            /Users/nandub/development/code/ikvm-conv/nant/src/NAnt.Console/NAnt.Console.build(15,10):
            External Program Failed: /usr/local/lib/pkgconfig/../../lib/mono/4.5/mcs.exe (return code was 1)
```